### PR TITLE
syntax changed in latest brew  

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,5 +56,5 @@ For Homebrew users, it is also available as a Cask:
 
 ```sh
 $ brew tap homebrew/cask-drivers
-$ brew cask install qmk-toolbox
+$ brew install --cask qmk-toolbox
 ```


### PR DESCRIPTION
syntax changed in latest brew   
Error: Calling `brew cask install` is disabled! Use brew install [--cask] instead.
## Description

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ x ] Documentation

